### PR TITLE
Allow redis client injection

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,9 +3,14 @@ const lock = require('lock').Lock();
 const memoryCache = require('memory-cache');
 const redis = require('redis');
 
-function PettyCache(port, host, options) {
+function PettyCache(options) {
     const intervals = {};
-    const redisClient = redis.createClient(port || 6379, host || '127.0.0.1', options);
+    let redisClient;
+    if (options instanceof redis.RedisClient) {
+      redisClient = options;
+    } else {
+      redisClient = redis.createClient(options);
+    }
 
     redisClient.on('error', err => console.warn(`Warning: Redis reported a client error: ${err}`));
 

--- a/test/index.js
+++ b/test/index.js
@@ -6,8 +6,8 @@ const redis = require('redis');
 
 const PettyCache = require('../index.js');
 
-const pettyCache = new PettyCache();
 var redisClient = redis.createClient();
+const pettyCache = new PettyCache(redisClient);
 
 describe('memory-cache', function() {
     it('memoryCache.put(key, \'\')', function(done) {
@@ -956,7 +956,7 @@ describe('PettyCache.fetchAndRefresh', function() {
 
         pettyCache.fetchAndRefresh(key, func, { ttl: 6000 });
 
-        const pettyCache2 = new PettyCache();
+        const pettyCache2 = new PettyCache(redisClient);
 
         pettyCache2.fetchAndRefresh(key, func, { ttl: 6000 }, function(err, data) {
             assert.equal(data, 1);


### PR DESCRIPTION
Allow Redis Client injection in the pretty cache to allow more API and function. Some example use cases:
* Change DB (default is always 0)
* Allow choosing a different version of Redis client - https://github.com/mediocre/petty-cache/issues/9